### PR TITLE
Improve responsiveness

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -6,9 +6,11 @@ class MyDocument extends Document {
     return (
       <Html>
         <Head>
+          {/* Meta viewport for responsive design */}
+          <meta name="viewport" content="width=device-width, initial-scale=1" />
           {/* Include the three.js library from CDN */}
-  <Script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js" strategy="beforeInteractive" />
-  <Script src="https://cdnjs.cloudflare.com/ajax/libs/vanta/0.5.24/vanta.waves.min.js" strategy="beforeInteractive" />
+          <Script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js" strategy="beforeInteractive" />
+          <Script src="https://cdnjs.cloudflare.com/ajax/libs/vanta/0.5.24/vanta.waves.min.js" strategy="beforeInteractive" />
         </Head>
         <body>
           <Main />

--- a/src/styles/Container.module.css
+++ b/src/styles/Container.module.css
@@ -1,7 +1,51 @@
 .container {
-    width: 100%;
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 0 20px;
-    box-sizing: border-box;
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 20px;
+  box-sizing: border-box;
+}
+
+/* Adjust padding for tablets and phones */
+@media (max-width: 1024px) {
+  .container {
+    padding: 0 16px;
   }
+}
+
+@media (max-width: 768px) {
+  .container {
+    padding: 0 12px;
+  }
+}
+
+@media (max-width: 425px) {
+  .container {
+    padding: 0 10px;
+  }
+}
+
+@media (max-width: 375px) {
+  .container {
+    padding: 0 8px;
+  }
+}
+
+@media (max-width: 320px) {
+  .container {
+    padding: 0 5px;
+  }
+}
+
+/* Larger desktop screens */
+@media (min-width: 1440px) {
+  .container {
+    max-width: 1400px;
+  }
+}
+
+@media (min-width: 2160px) {
+  .container {
+    max-width: 1800px;
+  }
+}


### PR DESCRIPTION
## Summary
- add viewport meta tag for mobile responsiveness
- tweak container widths and padding with media queries for 320-2160px

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686838d50b9c8333a36b7742011f4130