### PR TITLE
Add responsive breakpoints

### DIFF
--- a/src/styles/Audit.module.css
+++ b/src/styles/Audit.module.css
@@ -115,3 +115,37 @@
     border-radius: 8px; /* Optional: Rounds edges */
     color: white; /* Set response section text color to white */
   }
+
+/* Additional responsive breakpoints */
+@media (max-width: 425px) {
+  .form {
+    padding: 8px;
+  }
+  .title {
+    font-size: 1.5rem;
+  }
+}
+
+@media (max-width: 375px) {
+  .title {
+    font-size: 1.3rem;
+  }
+}
+
+@media (max-width: 320px) {
+  .title {
+    font-size: 1.2rem;
+  }
+}
+
+@media (min-width: 1440px) {
+  .form {
+    max-width: 1400px;
+  }
+}
+
+@media (min-width: 2160px) {
+  .form {
+    max-width: 1600px;
+  }
+}

--- a/src/styles/ComingSoonOverlay.module.css
+++ b/src/styles/ComingSoonOverlay.module.css
@@ -77,6 +77,18 @@
   }
 }
 
+@media (max-width: 375px) {
+  .comingSoonImage {
+    max-width: 95vw;
+  }
+}
+
+@media (max-width: 320px) {
+  .comingSoonImage {
+    max-width: 100vw;
+  }
+}
+
 /* Small tablets (426px - 767px) */
 @media (max-width: 768px) {
   .comingSoonImage {
@@ -95,6 +107,13 @@
 @media (min-width: 1440px) {
   .comingSoonImage {
     max-width: 500px;
+  }
+}
+
+/* Large screens (2160px+) */
+@media (min-width: 2160px) {
+  .comingSoonImage {
+    max-width: 650px;
   }
 }
 

--- a/src/styles/Footer.module.css
+++ b/src/styles/Footer.module.css
@@ -411,6 +411,30 @@
   }
 }
 
+@media (max-width: 425px) {
+  .footerTitle {
+    font-size: 1.7rem;
+  }
+}
+
+@media (max-width: 320px) {
+  .footerTitle {
+    font-size: 1.5rem;
+  }
+}
+
+@media (min-width: 1440px) {
+  .container {
+    max-width: 1400px;
+  }
+}
+
+@media (min-width: 2160px) {
+  .container {
+    max-width: 1600px;
+  }
+}
+
 @media (max-width: 375px) {
   .footerTitle {
     font-size: 1.6rem;

--- a/src/styles/Hero.module.css
+++ b/src/styles/Hero.module.css
@@ -458,6 +458,15 @@
   }
 }
 
+@media (min-width: 2160px) {
+  .heroMain {
+    max-width: 1800px;
+  }
+  .expandedSection {
+    max-width: 1600px;
+  }
+}
+
 @media (min-width: 1440px) and (max-width: 1919px) {
   .heroMain {
     max-width: 1400px;
@@ -631,7 +640,7 @@
   }
 }
 
-@media (max-width: 424px) and (min-width: 320px) {
+@media (max-width: 425px) and (min-width: 320px) {
   .hero {
     padding: 40px 0 25px 0;
   }
@@ -715,7 +724,7 @@
   }
 }
 
-@media (max-width: 374px) {
+@media (max-width: 375px) {
   .hero {
     padding: 35px 0 20px 0;
   }
@@ -801,5 +810,11 @@
   .bulletList li::before {
     left: 0;
     top: 10px;
+  }
+}
+
+@media (max-width: 320px) {
+  .heroText h1 {
+    font-size: 1.8rem;
   }
 }

--- a/src/styles/Home.module.css
+++ b/src/styles/Home.module.css
@@ -78,3 +78,57 @@
   font-size: 1.25rem;
   line-height: 1.5;
 }
+
+/* Responsive Styles */
+@media (max-width: 1024px) {
+  .title {
+    font-size: 3rem;
+  }
+  .description {
+    font-size: 1.25rem;
+  }
+}
+
+@media (max-width: 768px) {
+  .title {
+    font-size: 2.5rem;
+  }
+  .description {
+    font-size: 1.1rem;
+    margin: 2rem 0;
+  }
+}
+
+@media (max-width: 425px) {
+  .title {
+    font-size: 2rem;
+  }
+  .description {
+    font-size: 1rem;
+    padding: 0 1rem;
+  }
+}
+
+@media (max-width: 375px) {
+  .title {
+    font-size: 1.8rem;
+  }
+}
+
+@media (max-width: 320px) {
+  .title {
+    font-size: 1.6rem;
+  }
+}
+
+@media (min-width: 1440px) {
+  .title {
+    font-size: 4.5rem;
+  }
+}
+
+@media (min-width: 2160px) {
+  .title {
+    font-size: 5rem;
+  }
+}

--- a/src/styles/MintButton.module.css
+++ b/src/styles/MintButton.module.css
@@ -24,3 +24,25 @@
   cursor: not-allowed;
   opacity: 0.7;
 }
+
+/* Responsive breakpoints */
+@media (max-width: 425px) {
+  .mintButton {
+    font-size: 1rem;
+    padding: 12px 28px;
+  }
+}
+
+@media (max-width: 375px) {
+  .mintButton {
+    font-size: 0.95rem;
+    padding: 10px 24px;
+  }
+}
+
+@media (max-width: 320px) {
+  .mintButton {
+    font-size: 0.9rem;
+    padding: 8px 20px;
+  }
+}

--- a/src/styles/NFTs.module.css
+++ b/src/styles/NFTs.module.css
@@ -167,3 +167,40 @@
   margin-bottom: 10px;
   font-weight: 600;
 }
+
+/* Additional responsive breakpoints */
+@media (max-width: 425px) {
+  .nftsTitle {
+    font-size: 2rem;
+  }
+  .nftsDescription {
+    font-size: 1rem;
+  }
+  .upcomingContainer {
+    gap: 24px;
+  }
+}
+
+@media (max-width: 375px) {
+  .nftsTitle {
+    font-size: 1.8rem;
+  }
+}
+
+@media (max-width: 320px) {
+  .nftsTitle {
+    font-size: 1.6rem;
+  }
+}
+
+@media (min-width: 1440px) {
+  .nftsContainer {
+    max-width: 1400px;
+  }
+}
+
+@media (min-width: 2160px) {
+  .nftsContainer {
+    max-width: 1600px;
+  }
+}

--- a/src/styles/Navbar.module.css
+++ b/src/styles/Navbar.module.css
@@ -429,3 +429,27 @@
     font-size: 1.1rem;
   }
 }
+
+@media (max-width: 425px) {
+  .navbarContainer {
+    padding: 0 11px;
+  }
+}
+
+@media (max-width: 320px) {
+  .brandText {
+    font-size: 0.9rem;
+  }
+}
+
+@media (min-width: 1440px) {
+  .navbarContainer {
+    max-width: 1400px;
+  }
+}
+
+@media (min-width: 2160px) {
+  .navbarContainer {
+    max-width: 1600px;
+  }
+}

--- a/src/styles/Presale.module.css
+++ b/src/styles/Presale.module.css
@@ -626,6 +626,30 @@
   }
 }
 
+@media (max-width: 425px) {
+  .tokenTitle {
+    font-size: 2.3rem;
+  }
+}
+
+@media (max-width: 320px) {
+  .tokenTitle {
+    font-size: 2rem;
+  }
+}
+
+@media (min-width: 1440px) {
+  .container {
+    max-width: 1400px;
+  }
+}
+
+@media (min-width: 2160px) {
+  .container {
+    max-width: 1600px;
+  }
+}
+
 @media (max-width: 375px) {
   .tokenTitle {
     font-size: 2.2rem;

--- a/src/styles/Roadmap.module.css
+++ b/src/styles/Roadmap.module.css
@@ -464,3 +464,27 @@
     width: 2px;
   }
 }
+
+@media (max-width: 425px) {
+  .roadmapTitle {
+    font-size: 2.3rem;
+  }
+}
+
+@media (max-width: 320px) {
+  .roadmapTitle {
+    font-size: 2rem;
+  }
+}
+
+@media (min-width: 1440px) {
+  .timeline {
+    max-width: 1100px;
+  }
+}
+
+@media (min-width: 2160px) {
+  .timeline {
+    max-width: 1300px;
+  }
+}

--- a/src/styles/Tokenomics.module.css
+++ b/src/styles/Tokenomics.module.css
@@ -75,3 +75,52 @@
     padding: 12px 0;
   }
 }
+
+/* Additional responsive breakpoints */
+@media (max-width: 1024px) {
+  .tokenomicsContent {
+    gap: 40px;
+  }
+}
+
+@media (max-width: 768px) {
+  .tokenomicsTitle {
+    font-size: 2rem;
+  }
+  .tokenomicsContent {
+    gap: 24px;
+  }
+}
+
+@media (max-width: 425px) {
+  .tokenomicsTitle {
+    font-size: 1.8rem;
+  }
+  .tokenomicsInfo {
+    font-size: 1rem;
+  }
+}
+
+@media (max-width: 375px) {
+  .tokenomicsTitle {
+    font-size: 1.6rem;
+  }
+}
+
+@media (max-width: 320px) {
+  .tokenomicsTitle {
+    font-size: 1.5rem;
+  }
+}
+
+@media (min-width: 1440px) {
+  .tokenomicsContent {
+    max-width: 1300px;
+  }
+}
+
+@media (min-width: 2160px) {
+  .tokenomicsContent {
+    max-width: 1500px;
+  }
+}


### PR DESCRIPTION
## Summary
- update Home styles for multiple screen sizes
- add additional breakpoints for Audit page
- ensure ComingSoon overlay, footer, hero, NFT, navbar, presale, roadmap, mint button and tokenomics components react to 320px-2160px widths

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68683c112f3483339c3cc5944ac39dec